### PR TITLE
Verify bug fix, fetchByUsername may return false for invalid login, inst...

### DIFF
--- a/src/Jasny/Auth.php
+++ b/src/Jasny/Auth.php
@@ -73,7 +73,7 @@ abstract class Auth
     {
         $user = static::fetchUserByUsername($username);
         
-        if (!isset($user) || $user->getPassword() !== static::password($password, $user->getPassword())) return false;
+        if (!isset($user) || !$user || $user->getPassword() !== static::password($password, $user->getPassword())) return false;
         return $user;
     }
     


### PR DESCRIPTION
Verify bug fix, fetchByUsername may return false for invalid login, instead of empty model that implements the getPassword methods resulting in a fatal error. Verify should check for false and not presume fetchByUsername always returns user model.

$user is always 'set' so the isset check is redundant 
