### PR TITLE
Use secret as hmac for hashid confirmation checksum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.4snapshot
+  - 7.4
   - nightly
 
 matrix:

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -333,7 +333,6 @@ class Auth implements Authz
      * Set the current user and dispatch login event.
      *
      * @throws LoginException
-     * @noinspection PhpDocMissingThrowsInspection
      */
     private function loginUser(User $user): void
     {
@@ -369,7 +368,6 @@ class Auth implements Authz
      * Set the current user and dispatch login event.
      *
      * @throws LoginException
-     * @noinspection PhpDocMissingThrowsInspection
      */
     private function partialLoginUser(User $user): void
     {

--- a/src/Confirmation/HashidsConfirmation.php
+++ b/src/Confirmation/HashidsConfirmation.php
@@ -27,9 +27,9 @@ class HashidsConfirmation implements ConfirmationInterface
     protected \Closure $createHashids;
     protected Storage $storage;
 
-    /** @var \Closure&callable(string $uid):(string|false) */
+    /** @phpstan-var \Closure&callable(string $uid):(string|false) */
     protected \Closure $encodeUid;
-    /** @var \Closure&callable(string $uid):(string|false) */
+    /** @phpstan-var \Closure&callable(string $uid):(string|false) */
     protected \Closure $decodeUid;
 
     protected Logger $logger;
@@ -37,8 +37,8 @@ class HashidsConfirmation implements ConfirmationInterface
     /**
      * HashidsConfirmation constructor.
      *
-     * @param string                   $secret
-     * @param callable(string):Hashids $createHashids
+     * @phpstan-param string                        $secret
+     * @phpstan-param null|callable(string):Hashids $createHashids
      */
     public function __construct(string $secret, ?callable $createHashids = null)
     {
@@ -299,7 +299,7 @@ class HashidsConfirmation implements ConfirmationInterface
             $this->secret,
         ];
 
-        return hash_hmac('sha256', join("\0", $parts));
+        return hash('sha256', join("\0", $parts));
     }
 
 

--- a/src/Confirmation/HashidsConfirmation.php
+++ b/src/Confirmation/HashidsConfirmation.php
@@ -242,8 +242,9 @@ class HashidsConfirmation implements ConfirmationInterface
     protected function verifyChecksum(string $checksum, User $user, CarbonImmutable $expire, array $context): void
     {
         $expected = $this->calcChecksum($user, $expire);
+        $expectedOld = $this->calcOldChecksum($user, $expire);
 
-        if ($checksum === $expected) {
+        if ($checksum === $expected || $checksum === $expectedOld) {
             return;
         }
 
@@ -278,10 +279,27 @@ class HashidsConfirmation implements ConfirmationInterface
             CarbonImmutable::instance($expire)->utc()->format('YmdHis'),
             $user->getAuthId(),
             $user->getAuthChecksum(),
-            $this->secret
         ];
 
-        return hash('sha256', join("\0", $parts));
+        return hash_hmac('sha256', join("\0", $parts), $this->secret);
+    }
+
+    /**
+     * Calculate confirmation checksum, before switching to hmac.
+     * Temporary so existing confirmation tokens will continue working. Will be removed.
+     *
+     * @deprecated
+     */
+    protected function calcOldChecksum(User $user, \DateTimeInterface $expire): string
+    {
+        $parts = [
+            CarbonImmutable::instance($expire)->utc()->format('YmdHis'),
+            $user->getAuthId(),
+            $user->getAuthChecksum(),
+            $this->secret,
+        ];
+
+        return hash_hmac('sha256', join("\0", $parts));
     }
 
 

--- a/tests/Confirmation/HashidsConfirmationTest.php
+++ b/tests/Confirmation/HashidsConfirmationTest.php
@@ -23,8 +23,9 @@ class HashidsConfirmationTest extends TestCase
     use ExpectWarningTrait;
     use CallbackMockTrait;
 
-    protected const TOKEN = '57ZOXP4dxYhQ7Yqne191TvgvnAjxJasoybbr84enIV8oa1GEJqiYPx47gxm5CVa6Me0Mo';
-    protected const STD_HEX = '8930d6fab596adc131412a8309d5391611047dcf9dad6e106ccbb5b8ee2ae7fb202001011200003432';
+    protected const TOKEN = 'kR2wngZKmZsKRN6xWKy7U1qEWBnWxaf60YjPDakjcXKB1v2rOZt831bDOGk6hJ6WBgGBm';
+    protected const STD_HEX = '43b87e6e92e84566b79f6f16ee4c982accec20d16bc3e46c8656bcef93dafba6202001011200003432';
+    protected const OLD_HEX = '8930d6fab596adc131412a8309d5391611047dcf9dad6e106ccbb5b8ee2ae7fb202001011200003432';
 
     /** @var User&MockObject */
     protected $user;
@@ -144,6 +145,16 @@ class HashidsConfirmationTest extends TestCase
     public function testFrom()
     {
         $confirm = $this->createService(self::STD_HEX, $this->user);
+
+        $this->logger->expects($this->once())->method('info')
+            ->with('Verified confirmation token', $this->expectedContext('42', '2020-01-01T12:00:00+00:00'));
+
+        $this->assertSame($this->user, $confirm->from(self::TOKEN));
+    }
+
+    public function testFromWithOldToken()
+    {
+        $confirm = $this->createService(self::OLD_HEX, $this->user);
 
         $this->logger->expects($this->once())->method('info')
             ->with('Verified confirmation token', $this->expectedContext('42', '2020-01-01T12:00:00+00:00'));


### PR DESCRIPTION
Added `calcOldChecksum()` so existing tokens will not be invalid after updating.
TODO: tests